### PR TITLE
fix(website): align dual-face navigation flow

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -592,6 +592,9 @@ p { color: var(--fg); }
 .site-foot__top { display: grid; grid-template-columns: 1.4fr 1fr 1fr; gap: clamp(24px, 4vw, 48px); }
 .site-foot__brand .brandlock { margin-bottom: 14px; }
 .site-foot__brand p { color: var(--muted); font-size: .9rem; max-width: 34ch; }
+.foot-entry-links { display: flex; flex-wrap: wrap; gap: 10px 16px; margin-top: 16px; }
+.foot-entry-links a { color: var(--brand); font-size: .86rem; font-weight: 600; }
+.foot-entry-links a:hover { text-decoration: underline; text-underline-offset: 3px; }
 .foot-agent-link {
   display: inline-flex; align-items: center; gap: 5px; margin-top: 14px;
   font-size: .88rem; font-weight: 600; color: var(--brand);
@@ -664,10 +667,10 @@ html.js .reveal.in { opacity: 1; transform: none; }
   html.js .reveal { opacity: 1; transform: none; }
 }
 
-/* ---------- 双门：人类面 / 智能体面入口卡片（中性根页） ----------
+/* ---------- 三入口：人类面 / 智能体面 / 共享文档（中性根页） ----------
    卡片语言沿用 .capcard / .shot：细线边框 + 圆角 + 悬停上浮。
    整卡可点由 .door__link::after 拉伸覆盖；链接可访问名仅 “人类 →”，不含整段定位文。 */
-.doors { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(18px, 2.4vw, 28px); }
+.doors { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: clamp(18px, 2.4vw, 28px); }
 .door {
   position: relative;
   display: flex; flex-direction: column; gap: 16px;
@@ -694,6 +697,10 @@ html.js .reveal.in { opacity: 1; transform: none; }
 .door__arrow { transition: transform var(--duration-normal) var(--ease-out); }
 .door:hover .door__link { gap: 12px; }
 .door:hover .door__arrow { transform: translateX(3px); }
+
+@media (max-width: 1080px) {
+  .doors { grid-template-columns: 1fr 1fr; }
+}
 
 @media (max-width: 900px) {
   .doors { grid-template-columns: 1fr; }

--- a/website/content/agents/index.en.md
+++ b/website/content/agents/index.en.md
@@ -1,4 +1,5 @@
 ---
 title: "Agents · 双面搜 / Juso"
 description: "Local AI agents call configured AI search APIs or search conventional engines through a Chrome-family browser or Firefox with Juso installed. Credentials stay inside the extension."
+type: "agents"
 ---

--- a/website/content/agents/index.md
+++ b/website/content/agents/index.md
@@ -1,4 +1,6 @@
 ---
 title: "智能体 · 双面搜 / Juso"
 description: "本地 AI 智能体通过装有双面搜的 Chrome 系浏览器或 Firefox 调用已配置 AI 搜索 API，或借真实浏览器检索传统搜索引擎。密钥始终留在扩展内。"
+type: "agents"
+url: "/agents/"
 ---

--- a/website/content/human/index.en.md
+++ b/website/content/human/index.en.md
@@ -1,4 +1,5 @@
 ---
 title: "People · 双面搜 / Juso"
 description: "An open-source, two-sided search gateway with locally managed credentials—for humans and local AI agents."
+type: "human"
 ---

--- a/website/content/human/index.md
+++ b/website/content/human/index.md
@@ -1,4 +1,6 @@
 ---
 title: "人类 · 双面搜 / Juso"
 description: "双面搜 / Juso 是一个开源的搜索聚合与切换工具：把传统搜索引擎、站外搜索（Site Engine）和你已配置的 AI 搜索服务统一到同一个入口。"
+type: "human"
+url: "/human/"
 ---

--- a/website/i18n/en.yaml
+++ b/website/i18n/en.yaml
@@ -323,9 +323,9 @@ docs_cta_p:
 
 # Documentation tree (/docs/, /human/docs/, /agents/docs/)
 docs_hub_title:
-  other: "Choose your documentation path"
+  other: "Start with the shared Juso foundation"
 docs_hub_sub:
-  other: "Juso is one browser extension, but searching for yourself and connecting local agents are different workflows. Install the extension first, then enter the complete guide that fits your use."
+  other: "Whether you search for yourself or let a local agent search, begin with the same extension, installation prerequisites, and data boundaries; then enter the independent guide for your side."
 docs_hub_human_tag:
   other: "PEOPLE USE"
 docs_hub_human_title:
@@ -401,7 +401,7 @@ human_doc_local_title:
 human_doc_local_body:
   other: "Successful AI searches are cached per service and normalised query on the current device, and history can be replayed. Refresh for fresh results. Configuration export includes unencrypted keys and preferences, so create it only for a deliberate backup and store it safely."
 human_doc_open_app:
-  other: "Open people-face overview"
+  other: "Go to getting started"
 agents_doc_eyebrow:
   other: "AGENTS DOCUMENTATION"
 agents_doc_title:
@@ -447,4 +447,4 @@ agents_doc_recovery_body:
 agents_doc_mcp_link:
   other: "Read MCP Server configuration"
 agents_doc_open_app:
-  other: "Open agents-face overview"
+  other: "Go to prerequisites"

--- a/website/i18n/zh.yaml
+++ b/website/i18n/zh.yaml
@@ -323,9 +323,9 @@ docs_cta_p:
 
 # 文档树（/docs/、/human/docs/、/agents/docs/）
 docs_hub_title:
-  other: "选择你的文档路径"
+  other: "从共同基础开始使用双面搜"
 docs_hub_sub:
-  other: "双面搜由同一个浏览器扩展承载，但人类使用与本地智能体接入是两条不同的工作流。先安装扩展，再进入适合你的完整指南。"
+  other: "无论你自己搜索，还是让本地智能体搜索，都先从同一个扩展、同一套安装前置与数据边界开始；完成后再进入人类或智能体的独立指南。"
 docs_hub_human_tag:
   other: "人类使用"
 docs_hub_human_title:
@@ -401,7 +401,7 @@ human_doc_local_title:
 human_doc_local_body:
   other: "成功的 AI 搜索会按服务与规范化查询缓存在当前设备，历史可重放。需要最新结果时使用刷新；配置导出包含未加密的密钥与偏好，应仅在你主动需要备份时创建并安全保管。"
 human_doc_open_app:
-  other: "打开人类面概览"
+  other: "进入开始使用"
 agents_doc_eyebrow:
   other: "AGENTS DOCUMENTATION"
 agents_doc_title:
@@ -447,4 +447,12 @@ agents_doc_recovery_body:
 agents_doc_mcp_link:
   other: "阅读 MCP Server 配置"
 agents_doc_open_app:
-  other: "打开智能体面概览"
+  other: "进入接入前置条件"
+
+# 共享安装中心与首页三入口
+home_door_docs_copy:
+  other: "共同安装、搜索与两面使用指南"
+home_door_docs_link:
+  other: "开始使用"
+hero_shared_docs_link:
+  other: "共同安装与使用"

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -13,9 +13,9 @@
 
   {{/* canonical + hreflang：自身 + .Translations 互指 + x-default 指向中文版 */}}
   <link rel="canonical" href="{{ .Permalink }}">
-  <link rel="alternate" hreflang="{{ .Site.Language.Locale }}" href="{{ .Permalink }}">
+  <link rel="alternate" hreflang="{{ .Site.Language.Lang }}" href="{{ .Permalink }}">
   {{ range .Translations }}
-  <link rel="alternate" hreflang="{{ .Language.Locale }}" href="{{ .Permalink }}">
+  <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}">
   {{ end }}
   {{ $zhURL := .Permalink }}{{ range .Translations }}{{ if eq .Language.Lang "zh" }}{{ $zhURL = .Permalink }}{{ end }}{{ end }}
   <link rel="alternate" hreflang="x-default" href="{{ $zhURL }}">
@@ -23,7 +23,7 @@
   <meta property="og:title" content="{{ .Title }}">
   <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.githubDesc }}{{ end }}">
   <meta property="og:image" content="{{ "img/promo-1400x560.png" | absURL }}">
-  <meta property="og:locale" content="{{ replace .Site.Language.Locale "-" "_" }}">
+  <meta property="og:locale" content="{{ replace .Site.Language.Lang "-" "_" }}">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="{{ "img/promo-1400x560.png" | absURL }}">

--- a/website/layouts/agents-docs/single.html
+++ b/website/layouts/agents-docs/single.html
@@ -8,7 +8,7 @@
     <p class="eyebrow"><span></span>{{ i18n "agents_doc_eyebrow" }}</p>
     <h1>{{ i18n "agents_doc_title" }}</h1>
     <p>{{ i18n "agents_doc_sub" }}</p>
-    <a class="btn btn--primary" href="{{ "agents/" | relLangURL }}">{{ i18n "agents_doc_open_app" }}</a>
+    <a class="btn btn--primary" href="#requirements">{{ i18n "agents_doc_open_app" }}</a>
   </div>
 </section>
 

--- a/website/layouts/agents/single.html
+++ b/website/layouts/agents/single.html
@@ -12,6 +12,8 @@
   "cta_primary_href" .Site.Params.cwsURL
   "cta_ghost_key" "cta_github"
   "cta_ghost_href" .Site.Params.githubURL
+  "shared_href" ("docs/" | relLangURL)
+  "shared_key" "hero_shared_docs_link"
   "doc_href" ("agents/docs/" | relLangURL)
   "doc_key" "docs_hub_agents_link"
   "visual" "hero-visual-agent"

--- a/website/layouts/human-docs/single.html
+++ b/website/layouts/human-docs/single.html
@@ -8,7 +8,7 @@
     <p class="eyebrow"><span></span>{{ i18n "human_doc_eyebrow" }}</p>
     <h1>{{ i18n "human_doc_title" }}</h1>
     <p>{{ i18n "human_doc_sub" }}</p>
-    <a class="btn btn--primary" href="{{ "human/" | relLangURL }}">{{ i18n "human_doc_open_app" }}</a>
+    <a class="btn btn--primary" href="#start">{{ i18n "human_doc_open_app" }}</a>
   </div>
 </section>
 

--- a/website/layouts/human/single.html
+++ b/website/layouts/human/single.html
@@ -14,6 +14,8 @@
   "cta_primary_href" .Site.Params.cwsURL
   "cta_ghost_key" "cta_release"
   "cta_ghost_href" .Site.Params.releaseURL
+  "shared_href" ("docs/" | relLangURL)
+  "shared_key" "hero_shared_docs_link"
   "doc_href" ("human/docs/" | relLangURL)
   "doc_key" "docs_hub_human_link"
   "visual" "hero-visual-home"

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -17,7 +17,7 @@
   "scroll_target" "#doors"
 ) }}
 
-{{/* 双门 —— 人类面 / 智能体面 */}}
+{{/* 三入口 —— 人类面 / 智能体面 / 共享文档 */}}
 <section class="section section--sunk" id="doors">
   <div class="wrap">
     {{ partial "section-head.html" (dict "eyebrow" (i18n "hero_eyebrow") "title" (i18n "sec_faces") "sub" (i18n "sec_faces_sub")) }}
@@ -31,6 +31,11 @@
         <span class="door__face"><span class="door__dot" aria-hidden="true"></span>{{ i18n "face_agent" }}</span>
         <p class="door__copy">{{ i18n "hero_positioning_agents" }}</p>
         <a class="door__link" href="{{ "agents/" | relLangURL }}">{{ i18n "nav_agent" }}<span class="door__arrow" aria-hidden="true">→</span></a>
+      </div>
+      <div class="door door--docs">
+        <span class="door__face"><span class="door__dot" aria-hidden="true"></span>{{ i18n "nav_docs" }}</span>
+        <p class="door__copy">{{ i18n "home_door_docs_copy" }}</p>
+        <a class="door__link" href="{{ "docs/" | relLangURL }}">{{ i18n "home_door_docs_link" }}<span class="door__arrow" aria-hidden="true">→</span></a>
       </div>
     </div>
   </div>

--- a/website/layouts/partials/agent-capabilities.html
+++ b/website/layouts/partials/agent-capabilities.html
@@ -1,7 +1,7 @@
 {{/* 智能体能力网格 —— data/agent-capabilities.yaml */}}
 {{ $lang := .Site.Language.Lang }}
 <div class="capgrid reveal">
-  {{ range hugo.Data.agent_capabilities.items }}
+  {{ range site.Data.agent_capabilities.items }}
     {{ $title := partial "i18n-field.html" (dict "obj" . "field" "title" "lang" $lang) }}
     {{ $desc := partial "i18n-field.html" (dict "obj" . "field" "desc" "lang" $lang) }}
     <div class="capcard">

--- a/website/layouts/partials/agent-steps.html
+++ b/website/layouts/partials/agent-steps.html
@@ -1,7 +1,7 @@
 {{/* 智能体接入步骤 —— data/agent-setup.yaml */}}
 {{ $lang := .Site.Language.Lang }}
 <div class="steps reveal">
-  {{ range hugo.Data.agent_setup.steps }}
+  {{ range site.Data.agent_setup.steps }}
     {{ $title := partial "i18n-field.html" (dict "obj" . "field" "title" "lang" $lang) }}
     {{ $body := partial "i18n-field.html" (dict "obj" . "field" "body" "lang" $lang) }}
     <div class="step">

--- a/website/layouts/partials/capability-matrix.html
+++ b/website/layouts/partials/capability-matrix.html
@@ -1,6 +1,6 @@
 {{/* 双面能力矩阵 —— data/capabilities.yaml，两列对称，朱砂红脊柱 */}}
 {{ $lang := .Site.Language.Lang }}
-{{ $data := hugo.Data.capabilities.rows }}
+{{ $data := site.Data.capabilities.rows }}
 <div class="matrix reveal">
   <div class="matrix__face">
     <h3><span class="num">人</span>{{ i18n "face_human" }}</h3>

--- a/website/layouts/partials/cli.html
+++ b/website/layouts/partials/cli.html
@@ -1,6 +1,6 @@
 {{/* CLI 代码块 —— data/cli.yaml；prompt/comment 装饰性 span 加 aria-hidden */}}
 <div class="cli reveal">
-  {{ range hugo.Data.cli.items }}
+  {{ range site.Data.cli.items }}
     {{ $lang := $.Site.Language.Lang }}
     {{ $title := partial "i18n-field.html" (dict "obj" . "field" "title" "lang" $lang) }}
     {{ $cap := partial "i18n-field.html" (dict "obj" . "field" "cap" "lang" $lang) }}

--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -9,9 +9,11 @@
           {{ if eq $curLang "zh" }}<span class="brandlock__sep">/</span><span class="brandlock__en">{{ i18n "brand_latin" }}</span>{{ end }}
         </a>
         <p>{{ i18n "footer_tagline" }}</p>
-        <a class="foot-agent-link" href="{{ "agents/" | relLangURL }}">
-          {{ i18n "footer_agent_access" }}<span class="foot-agent-link__arrow" aria-hidden="true">→</span>
-        </a>
+        <nav class="foot-entry-links" aria-label="{{ i18n "face_switch_label" }}">
+          <a href="{{ "human/" | relLangURL }}">{{ i18n "nav_human" }}</a>
+          <a href="{{ "agents/" | relLangURL }}">{{ i18n "nav_agent" }}</a>
+          <a href="{{ "docs/" | relLangURL }}">{{ i18n "nav_docs" }}</a>
+        </nav>
       </div>
       <div class="site-foot__col">
         <h4>{{ i18n "footer_get" }}</h4>

--- a/website/layouts/partials/hero-visual-agent.html
+++ b/website/layouts/partials/hero-visual-agent.html
@@ -6,7 +6,7 @@
       <span class="lang">bash</span>
     </div>
     {{/* CLI 演示前两条命令 —— data/cli.yaml（与 cli.html 同源，避免重复内容） */}}
-    <pre class="cli__pre">{{ range $i, $item := first 2 hugo.Data.cli.items }}{{ $title := partial "i18n-field.html" (dict "obj" $item "field" "title" "lang" $.Page.Site.Language.Lang) }}<span class="cmt" aria-hidden="true"># {{ $title }}</span>
+    <pre class="cli__pre">{{ range $i, $item := first 2 site.Data.cli.items }}{{ $title := partial "i18n-field.html" (dict "obj" $item "field" "title" "lang" $.Page.Site.Language.Lang) }}<span class="cmt" aria-hidden="true"># {{ $title }}</span>
 {{ replaceRE `<span class="(prompt|cmt)"` `<span class="$1" aria-hidden="true"` $item.html | safeHTML }}{{ if eq $i 0 }}
 
 {{ end }}{{ end }}</pre>

--- a/website/layouts/partials/hero.html
+++ b/website/layouts/partials/hero.html
@@ -13,6 +13,9 @@
         <a class="btn btn--primary" href="{{ .cta_primary_href }}" target="_blank" rel="noopener">{{ partial "icon/chrome.svg" $p }}{{ i18n .cta_primary_key }}</a>
         <a class="btn btn--ghost" href="{{ .cta_ghost_href }}" target="_blank" rel="noopener">{{ i18n .cta_ghost_key }}</a>
       </div>
+      {{ with .shared_href }}
+      <a class="hero__doc-link reveal-load d5" href="{{ . }}">{{ i18n $.shared_key }} <span aria-hidden="true">→</span></a>
+      {{ end }}
       {{ with .doc_href }}
       <a class="hero__doc-link reveal-load d5" href="{{ . }}">{{ i18n $.doc_key }} <span aria-hidden="true">→</span></a>
       {{ end }}

--- a/website/layouts/partials/icon-wall.html
+++ b/website/layouts/partials/icon-wall.html
@@ -1,7 +1,7 @@
 {{/* 来源图标墙 —— data/sources.yaml */}}
 {{ $lang := .Site.Language.Lang }}
 <div class="iconwall">
-  {{ range hugo.Data.sources.groups }}
+  {{ range site.Data.sources.groups }}
     <div class="iconwall__group">
       <h3>{{ i18n (printf "group_%s" .key) }} <span class="count">{{ len .items }}</span></h3>
       <div class="iconwall__items">

--- a/website/layouts/partials/security.html
+++ b/website/layouts/partials/security.html
@@ -1,7 +1,7 @@
 {{/* 安全/隐私事实清单 —— data/security.yaml，face=human|agent */}}
 {{ $face := .face }}
 {{ $lang := .Page.Site.Language.Lang }}
-{{ $items := index hugo.Data.security $face }}
+{{ $items := index site.Data.security $face }}
 <div class="facts reveal">
   {{ range $items }}
     {{ $title := partial "i18n-field.html" (dict "obj" . "field" "title" "lang" $lang) }}


### PR DESCRIPTION
## Summary\n- Add homepage /human/, /agents/, and /docs/ entry points\n- Make /docs/ the shared installation center\n- Keep /human/docs/ and /agents/docs/ as independent guides\n- Remove guide-to-overview CTA loops\n\n## Validation\n- Hugo build passes\n- 12 core routes generated\n- CTA and guide loop checks pass