### PR TITLE
fix(website): add bottom documentation entry points

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -585,6 +585,9 @@ p { color: var(--fg); }
 .ctaband h2 { font-size: clamp(1.6rem, 3.4vw, 2.3rem); margin-bottom: 14px; }
 .ctaband p { color: var(--muted); margin-bottom: 28px; font-size: 1.05rem; }
 .ctaband__cta { display: flex; flex-wrap: wrap; gap: 14px; justify-content: center; }
+.ctaband__links { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px 22px; margin-top: 22px; }
+.ctaband__links a { color: var(--brand); font-size: .92rem; font-weight: 650; }
+.ctaband__links a:hover { text-decoration: underline; text-underline-offset: 3px; }
 
 /* ---------- 页脚 ---------- */
 .site-foot { border-top: 1px solid var(--border); background: var(--bg-soft); padding-block: clamp(40px, 6vw, 64px) 32px; }

--- a/website/i18n/en.yaml
+++ b/website/i18n/en.yaml
@@ -448,3 +448,13 @@ agents_doc_mcp_link:
   other: "Read MCP Server configuration"
 agents_doc_open_app:
   other: "Go to prerequisites"
+
+# Shared installation center and homepage third entry
+home_door_docs_copy:
+  other: "Shared installation, search, and both-face guides"
+home_door_docs_link:
+  other: "Get started"
+hero_shared_docs_link:
+  other: "Shared installation & usage"
+cta_next_steps:
+  other: "Next steps after reading"

--- a/website/i18n/zh.yaml
+++ b/website/i18n/zh.yaml
@@ -456,3 +456,5 @@ home_door_docs_link:
   other: "开始使用"
 hero_shared_docs_link:
   other: "共同安装与使用"
+cta_next_steps:
+  other: "读完后下一步"

--- a/website/layouts/agents/single.html
+++ b/website/layouts/agents/single.html
@@ -62,5 +62,9 @@
   "primary_href" .Site.Params.cwsURL
   "ghost_key" "cta_github"
   "ghost_href" .Site.Params.githubURL
+  "shared_href" ("docs/" | relLangURL)
+  "shared_key" "hero_shared_docs_link"
+  "guide_href" ("agents/docs/" | relLangURL)
+  "guide_key" "docs_hub_agents_link"
 ) }}
 {{ end }}

--- a/website/layouts/human/single.html
+++ b/website/layouts/human/single.html
@@ -122,5 +122,9 @@
   "primary_href" .Site.Params.cwsURL
   "ghost_key" "cta_release"
   "ghost_href" .Site.Params.releaseURL
+  "shared_href" ("docs/" | relLangURL)
+  "shared_key" "hero_shared_docs_link"
+  "guide_href" ("human/docs/" | relLangURL)
+  "guide_key" "docs_hub_human_link"
 ) }}
 {{ end }}

--- a/website/layouts/partials/cta-band.html
+++ b/website/layouts/partials/cta-band.html
@@ -9,6 +9,12 @@
           <a class="btn btn--primary" href="{{ .primary_href }}" target="_blank" rel="noopener">{{ partial "icon/chrome.svg" $p }}{{ i18n .primary_key }}</a>
           <a class="btn btn--ghost" href="{{ .ghost_href }}" target="_blank" rel="noopener">{{ i18n .ghost_key }}</a>
         </div>
+        {{ if or .shared_href .guide_href }}
+        <nav class="ctaband__links" aria-label="{{ i18n "cta_next_steps" }}">
+          {{ with .shared_href }}<a href="{{ . }}">{{ i18n $.shared_key }} <span aria-hidden="true">→</span></a>{{ end }}
+          {{ with .guide_href }}<a href="{{ . }}">{{ i18n $.guide_key }} <span aria-hidden="true">→</span></a>{{ end }}
+        </nav>
+        {{ end }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Add end-of-page next-step links on both /human/ and /agents/ pages. Each bottom CTA now links directly to shared /docs/ and its own execution guide, with mirrored Chinese and English labels.