### PR TITLE
fix(website): keep face selection focused

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -670,10 +670,10 @@ html.js .reveal.in { opacity: 1; transform: none; }
   html.js .reveal { opacity: 1; transform: none; }
 }
 
-/* ---------- 三入口：人类面 / 智能体面 / 共享文档（中性根页） ----------
+/* ---------- 双面入口：人类面 / 智能体面（中性根页） ----------
    卡片语言沿用 .capcard / .shot：细线边框 + 圆角 + 悬停上浮。
    整卡可点由 .door__link::after 拉伸覆盖；链接可访问名仅 “人类 →”，不含整段定位文。 */
-.doors { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: clamp(18px, 2.4vw, 28px); }
+.doors { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(18px, 2.4vw, 28px); }
 .door {
   position: relative;
   display: flex; flex-direction: column; gap: 16px;
@@ -700,10 +700,6 @@ html.js .reveal.in { opacity: 1; transform: none; }
 .door__arrow { transition: transform var(--duration-normal) var(--ease-out); }
 .door:hover .door__link { gap: 12px; }
 .door:hover .door__arrow { transform: translateX(3px); }
-
-@media (max-width: 1080px) {
-  .doors { grid-template-columns: 1fr 1fr; }
-}
 
 @media (max-width: 900px) {
   .doors { grid-template-columns: 1fr; }

--- a/website/layouts/human/single.html
+++ b/website/layouts/human/single.html
@@ -93,26 +93,6 @@
   </div>
 </section>
 
-{{/* 双面桥 —— Agent Bridge 揭示另一面 */}}
-<section class="section section--sunk">
-  <div class="wrap">
-    {{ partial "section-head.html" (dict "eyebrow" (i18n "face_agent") "title" (i18n "sec_bridge") "sub" (i18n "sec_bridge_sub")) }}
-    <div class="bridge bridge--single reveal">
-      <div class="shot">
-        <div class="windowbar" aria-hidden="true">
-          <span class="windowbar__dot"></span><span class="windowbar__dot"></span><span class="windowbar__dot"></span>
-        </div>
-        {{ $bridgeShot := "img/showcase/agent-bridge-zh-light.png" }}{{ if $isEn }}{{ $bridgeShot = "img/showcase/agent-bridge-en-dark.png" }}{{ end }}
-        <img src="{{ $bridgeShot | relURL }}" alt="{{ i18n "cap_agent_bridge" }}" loading="lazy" decoding="async" width="1600" height="900">
-        <div class="shot__cap"><b>{{ i18n "cap_agent_bridge" }}</b></div>
-      </div>
-      <div class="bridge__copy">
-        <a class="btn btn--ghost" href="{{ "agents/" | relLangURL }}">{{ i18n "sec_bridge_link" }}</a>
-      </div>
-    </div>
-  </div>
-</section>
-
 {{/* CTA */}}
 {{ partial "cta-band.html" (dict
   "Page" .

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -32,11 +32,6 @@
         <p class="door__copy">{{ i18n "hero_positioning_agents" }}</p>
         <a class="door__link" href="{{ "agents/" | relLangURL }}">{{ i18n "nav_agent" }}<span class="door__arrow" aria-hidden="true">→</span></a>
       </div>
-      <div class="door door--docs">
-        <span class="door__face"><span class="door__dot" aria-hidden="true"></span>{{ i18n "nav_docs" }}</span>
-        <p class="door__copy">{{ i18n "home_door_docs_copy" }}</p>
-        <a class="door__link" href="{{ "docs/" | relLangURL }}">{{ i18n "home_door_docs_link" }}<span class="door__arrow" aria-hidden="true">→</span></a>
-      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Remove the documentation card from the homepage face-selection area and remove the Agent Bridge cross-face section from the human overview page. Keep documentation reachable through global navigation and bottom next-step links.